### PR TITLE
Fork for glydways hosting buildkite plugin changes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":bomb: Triggers"
     plugins:
-      - monebag/monorepo-diff:
+      - glydways/monorepo-diff:
           diff: "cat ./e2e/one-match-one-miss"
           log_level: "debug"
           watch:
@@ -22,10 +22,8 @@ steps:
 
   - label: ":bomb: Testing notifications"
     plugins:
-      - monebag/monorepo-diff:
+      - glydways/monorepo-diff:
           diff: "cat ./e2e/multiple-paths"
-          notify:
-            - email: subash@monebag.com
           watch:
             - path:
                 - "user-service/infrastructure/"
@@ -34,7 +32,7 @@ steps:
 
   - label: ":bomb: Testing groups"
     plugins:
-      - monebag/monorepo-diff#v2.5.7:
+      - glydways/monorepo-diff#v2.5.7:
           diff: "cat ./e2e/multiple-paths"
           watch:
             - path:
@@ -46,7 +44,7 @@ steps:
 
   - label: ":bomb: Testing hooks"
     plugins:
-      - monebag/monorepo-diff#v2.5.7:
+      - glydways/monorepo-diff#v2.5.7:
           diff: "cat ./e2e/multiple-paths"
           watch:
             - path: "user-service/"
@@ -66,7 +64,7 @@ steps:
 
   - label: ":bomb: Testing wait"
     plugins:
-      - monebag/monorepo-diff:
+      - glydways/monorepo-diff:
           diff: "cat ./e2e/multiple-paths"
           watch:
             - path:
@@ -78,7 +76,7 @@ steps:
 
   - label: ":bomb: Testing triggers and commands"
     plugins:
-      - monebag/monorepo-diff:
+      - glydways/monorepo-diff:
           diff: "cat ./e2e/commands-or-triggers"
           watch:
             - path: "user-service/"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![e2e status](https://badge.buildkite.com/719d0b895285367c9c57a09e07f1e853148d2509f0667e0ae8.svg?branch=master)](https://buildkite.com/monebag/monorepo-diff-buildkite-plugin)
-[![codecov](https://codecov.io/gh/monebag/monorepo-diff-buildkite-plugin/branch/master/graph/badge.svg?token=DQ3B4FIYD2)](https://codecov.io/gh/monebag/monorepo-diff-buildkite-plugin)
-[![Publish](https://github.com/monebag/monorepo-diff-buildkite-plugin/actions/workflows/publish.yml/badge.svg)](https://github.com/monebag/monorepo-diff-buildkite-plugin/actions/workflows/publish.yml)
+[![e2e status](https://badge.buildkite.com/719d0b895285367c9c57a09e07f1e853148d2509f0667e0ae8.svg?branch=master)](https://buildkite.com/glydways/monorepo-diff-buildkite-plugin)
+[![codecov](https://codecov.io/gh/glydways/monorepo-diff-buildkite-plugin/branch/master/graph/badge.svg?token=DQ3B4FIYD2)](https://codecov.io/gh/glydways/monorepo-diff-buildkite-plugin)
+[![Publish](https://github.com/glydways/monorepo-diff-buildkite-plugin/actions/workflows/publish.yml/badge.svg)](https://github.com/glydways/monorepo-diff-buildkite-plugin/actions/workflows/publish.yml)
 
 # monorepo-diff-buildkite-plugin
 
@@ -18,7 +18,7 @@ If the version number is not provided then the most recent version of the plugin
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.9:
+      - glydways/monorepo-diff#v2.5.9:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -35,7 +35,7 @@ steps:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.9:
+      - glydways/monorepo-diff#v2.5.9:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           env:
@@ -153,7 +153,7 @@ Add `log_level` property to set the log level. Supported log levels are `debug` 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.9:
+      - glydways/monorepo-diff#v2.5.9:
           diff: "git diff --name-only HEAD~1"
           log_level: "debug" # defaults to "info"
           watch:
@@ -229,7 +229,7 @@ hooks:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.9:
+      - glydways/monorepo-diff#v2.5.9:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: app/cms/
@@ -261,4 +261,4 @@ Using commands, it is also possible to use this to upload other pipeline definit
 
 ## How to Contribute
 
-Please read [contributing guide](https://github.com/monebag/monorepo-diff-buildkite-plugin/blob/master/CONTRIBUTING.md).
+Please read [contributing guide](https://github.com/glydways/monorepo-diff-buildkite-plugin/blob/master/CONTRIBUTING.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
       dockerfile: ./tests/Dockerfile
   plugin_lint:
     image: buildkite/plugin-linter:latest
-    command: ['--id', 'monebag/monorepo-diff']
+    command: ['--id', 'glydways/monorepo-diff']
     volumes:
       - ".:/plugin"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/monebag/monorepo-diff-buildkite-plugin
+module github.com/glydways/monorepo-diff-buildkite-plugin
 
 go 1.19
 

--- a/hooks/command
+++ b/hooks/command
@@ -75,7 +75,7 @@ download_binary_and_run() {
   get_architecture || return 1
   local _arch="$RETVAL"
   local _executable="monorepo-diff-buildkite-plugin"
-  local _repo="https://github.com/monebag/monorepo-diff-buildkite-plugin"
+  local _repo="https://github.com/glydways/monorepo-diff-buildkite-plugin"
 
   get_version || return 1
   local _version="$RETVAL"

--- a/plugin.go
+++ b/plugin.go
@@ -82,7 +82,7 @@ type Step struct {
 	SoftFail  interface{}              `json:"soft_fail" yaml:"soft_fail,omitempty"`
 	RawNotify []map[string]interface{} `json:"notify" yaml:",omitempty"`
 	Notify    []StepNotify             `yaml:"notify,omitempty"`
-	Plugins    interface{}             `yaml:"plugins,omitempty"`
+	Plugins   interface{}              `yaml:"plugins,omitempty"`
 }
 
 // Agent is Buildkite agent definition

--- a/plugin.go
+++ b/plugin.go
@@ -44,11 +44,6 @@ type Group struct {
 	Steps []Step `yaml:"steps"`
 }
 
-// GithubStatusNotification is notification config for github_commit_status
-type GithubStatusNotification struct {
-	Context string `yaml:"context,omitempty"`
-}
-
 // EnvironmentSecret is config aws secret
 type GithubStatusNotification struct {
 	Context string `yaml:"context,omitempty"`

--- a/plugin.go
+++ b/plugin.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const pluginName = "github.com/monebag/monorepo-diff"
+const pluginName = "github.com/glydways/monorepo-diff"
 
 // Plugin buildkite monorepo diff plugin structure
 type Plugin struct {

--- a/plugin.go
+++ b/plugin.go
@@ -22,7 +22,7 @@ type Plugin struct {
 	Env           map[string]string
 	RawNotify     []map[string]interface{} `json:"notify" yaml:",omitempty"`
 	Notify        []PluginNotify           `yaml:"notify,omitempty"`
-	Plugins       interface{}                `yaml:"plugins,omitempty"`
+	Plugins       interface{}              `yaml:"plugins,omitempty"`
 }
 
 // HookConfig Plugin hook configuration
@@ -96,7 +96,6 @@ type Build struct {
 	RawEnv   interface{}       `json:"env" yaml:",omitempty"`
 	Env      map[string]string `yaml:"env,omitempty"`
 	MetaData map[string]string `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
-	// Notify  []Notify          `yaml:"notify,omitempty"`
 }
 
 // UnmarshalJSON set defaults properties

--- a/plugin.go
+++ b/plugin.go
@@ -22,6 +22,9 @@ type Plugin struct {
 	Env           map[string]string
 	RawNotify     []map[string]interface{} `json:"notify" yaml:",omitempty"`
 	Notify        []PluginNotify           `yaml:"notify,omitempty"`
+//	RawPlugins    []map[string]interface{} `json:"plugins" yaml:",omitempty"`
+//	Plugins       []Plugins                `yaml:"plugins,omitempty"`
+	RawPlugins       interface{}                `yaml:"plugins,omitempty"`
 }
 
 // HookConfig Plugin hook configuration
@@ -42,6 +45,11 @@ type Group struct {
 }
 
 // GithubStatusNotification is notification config for github_commit_status
+type GithubStatusNotification struct {
+	Context string `yaml:"context,omitempty"`
+}
+
+// EnvironmentSecret is config aws secret
 type GithubStatusNotification struct {
 	Context string `yaml:"context,omitempty"`
 }
@@ -81,6 +89,9 @@ type Step struct {
 	SoftFail  interface{}              `json:"soft_fail" yaml:"soft_fail,omitempty"`
 	RawNotify []map[string]interface{} `json:"notify" yaml:",omitempty"`
 	Notify    []StepNotify             `yaml:"notify,omitempty"`
+//	RawPlugins []map[string]interface{} `json:"plugins" yaml:",omitempty"`
+//	Plugins    []StepPlugins             `yaml:"plugins,omitempty"`
+	RawPlugins    interface{}             `yaml:"plugins,omitempty"`
 }
 
 // Agent is Buildkite agent definition

--- a/plugin.go
+++ b/plugin.go
@@ -22,9 +22,7 @@ type Plugin struct {
 	Env           map[string]string
 	RawNotify     []map[string]interface{} `json:"notify" yaml:",omitempty"`
 	Notify        []PluginNotify           `yaml:"notify,omitempty"`
-//	RawPlugins    []map[string]interface{} `json:"plugins" yaml:",omitempty"`
-//	Plugins       []Plugins                `yaml:"plugins,omitempty"`
-	RawPlugins       interface{}                `yaml:"plugins,omitempty"`
+	Plugins       interface{}                `yaml:"plugins,omitempty"`
 }
 
 // HookConfig Plugin hook configuration
@@ -44,7 +42,7 @@ type Group struct {
 	Steps []Step `yaml:"steps"`
 }
 
-// EnvironmentSecret is config aws secret
+// GithubStatusNotification is notification config for github_commit_status
 type GithubStatusNotification struct {
 	Context string `yaml:"context,omitempty"`
 }
@@ -84,9 +82,7 @@ type Step struct {
 	SoftFail  interface{}              `json:"soft_fail" yaml:"soft_fail,omitempty"`
 	RawNotify []map[string]interface{} `json:"notify" yaml:",omitempty"`
 	Notify    []StepNotify             `yaml:"notify,omitempty"`
-//	RawPlugins []map[string]interface{} `json:"plugins" yaml:",omitempty"`
-//	Plugins    []StepPlugins             `yaml:"plugins,omitempty"`
-	RawPlugins    interface{}             `yaml:"plugins,omitempty"`
+	Plugins    interface{}             `yaml:"plugins,omitempty"`
 }
 
 // Agent is Buildkite agent definition

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: Monorepo Diff
 description: Trigger pipelines on changes in watched folders
-author: https://github.com/monebag
+author: https://github.com/glydways
 requirements:
   - git
 configuration:

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -20,7 +20,7 @@ func TestPluginWithInvalidParameter(t *testing.T) {
 
 func TestPluginShouldHaveDefaultValues(t *testing.T) {
 	param := `[{
-		"github.com/monebag/monorepo-diff-buildkite-plugin#commit": {}
+		"github.com/glydways/monorepo-diff-buildkite-plugin#commit": {}
 	}]`
 
 	got, _ := initializePlugin(param)
@@ -46,7 +46,7 @@ func TestPluginWithValidParameter(t *testing.T) {
 
 func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 	param := `[{
-		"github.com/monebag/monorepo-diff-buildkite-plugin#commit": {
+		"github.com/glydways/monorepo-diff-buildkite-plugin#commit": {
 			"diff": "cat ./hello.txt",
 			"wait": true,
 			"log_level": "debug",
@@ -269,7 +269,7 @@ func TestPluginShouldOnlyFullyUnmarshallItselfAndNotOtherPlugins(t *testing.T) {
 			}
 		},
 		{
-			"github.com/monebag/monorepo-diff-buildkite-plugin#commit": {
+			"github.com/glydways/monorepo-diff-buildkite-plugin#commit": {
 				"watch": [
 					{
 						"env": [
@@ -295,7 +295,7 @@ func TestPluginShouldOnlyFullyUnmarshallItselfAndNotOtherPlugins(t *testing.T) {
 func TestPluginShouldErrorIfPluginConfigIsInvalid(t *testing.T) {
 	param := `[
 		{
-			"github.com/monebag/monorepo-diff-buildkite-plugin#commit": {
+			"github.com/glydways/monorepo-diff-buildkite-plugin#commit": {
 				"env": {
 					"anInvalidKey": "An Invalid Value"
 				},

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -20,7 +20,7 @@ setup() {
   LOG_LEVEL="debug"
 
   export BUILDKITE_PLUGINS='[{
-    "github.com/monebag/monorepo-diff-buildkite-plugin": {
+    "github.com/glydways/monorepo-diff-buildkite-plugin": {
       "diff":"echo foo-service/",
       "log_level": "debug",
       "watch": [
@@ -58,7 +58,7 @@ EOM
   export BUILDKITE_COMMIT="commit-hash"
 
   export BUILDKITE_PLUGINS='[{
-    "github.com/monebag/monorepo-diff-buildkite-plugin": {
+    "github.com/glydways/monorepo-diff-buildkite-plugin": {
       "diff":"echo foo-service/ \nuser-service",
       "log_level": "debug",
       "notify": [
@@ -126,7 +126,7 @@ EOM
   export BUILDKITE_COMMIT="commit-hash"
 
   export BUILDKITE_PLUGINS='[{
-    "github.com/monebag/monorepo-diff-buildkite-plugin": {
+    "github.com/glydways/monorepo-diff-buildkite-plugin": {
       "diff":"echo foo-service/",
       "log_level": "debug",
       "watch": [
@@ -161,7 +161,7 @@ EOM
 
   export BUILDKITE_PLUGINS='[
   {
-    "github.com/monebag/monorepo-diff-buildkite-plugin": {
+    "github.com/glydways/monorepo-diff-buildkite-plugin": {
       "diff": "echo foo-service/ \nbat-service/",
       "log_level": "debug",
       "wait": true,


### PR DESCRIPTION
This PR migrates all github links to use `glydways` and to include a `plugin` that can be passed down to each sub step in the process. 