### PR TITLE
adding exclude syntax to match patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If the version number is not provided then the most recent version of the plugin
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.5.11:
+      - glydways/monorepo-diff#v2.6.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -38,7 +38,7 @@ steps:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.5.11:
+      - glydways/monorepo-diff#v2.6.0:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           env:
@@ -162,7 +162,7 @@ Add `log_level` property to set the log level. Supported log levels are `debug` 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.5.11:
+      - glydways/monorepo-diff#v2.6.0:
           diff: "git diff --name-only HEAD~1"
           log_level: "debug" # defaults to "info"
           watch:
@@ -238,7 +238,7 @@ hooks:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.5.11:
+      - glydways/monorepo-diff#v2.6.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: app/cms/

--- a/pipeline.go
+++ b/pipeline.go
@@ -113,7 +113,6 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 		}
 
 		if env("MONOREPO_DIFF_DEBUG", "") == "true" {
-			fmt.Println("Include Patterns:\n", includes)
 			fmt.Println("Exclude Patterns:\n", excludes)
 		}
 
@@ -141,6 +140,7 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 
 		if env("MONOREPO_DIFF_DEBUG", "") == "true" {
 			fmt.Println("Filtered Files:\n", include_files)
+			fmt.Println("Searching for Include Patterns:\n", includes)
 		}
 
 		// Iterate over the filtered files for any matches
@@ -153,6 +153,10 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 				// Add the step if an include was found
 				if match {
 					steps = append(steps, w.Step)
+					if env("MONOREPO_DIFF_DEBUG", "") == "true" {
+						fmt.Println("Found Match: \n", i)
+						fmt.Println("Adding Step: \n", w.Step)
+					}
 					break
 				}
 			}

--- a/pipeline.go
+++ b/pipeline.go
@@ -112,6 +112,11 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 			}
 		}
 
+		if env("MONOREPO_DIFF_DEBUG", "") == "true" {
+			fmt.Printf("Include Patterns:\n%s\n", string(includes))
+			fmt.Printf("Exclude Patterns:\n%s\n", string(excludes))
+		}
+
 		include_files := []string{}
 		// try to match the excludes
 		if len(excludes) != 0 {
@@ -134,6 +139,10 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 			include_files = files
 		}
 
+		if env("MONOREPO_DIFF_DEBUG", "") == "true" {
+			fmt.Printf("Filtered Files:\n%s\n", string(include_files))
+		}
+
 		// Iterate over the filtered files for any matches
 		for _, i := range includes {
 			for _, f := range include_files {
@@ -148,6 +157,10 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 				}
 			}
 		}
+	}
+
+	if env("MONOREPO_DIFF_DEBUG", "") == "true" {
+		fmt.Printf("Matched Steps:\n%s\n", string(steps))
 	}
 
 	return dedupSteps(steps), nil

--- a/pipeline.go
+++ b/pipeline.go
@@ -113,8 +113,8 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 		}
 
 		if env("MONOREPO_DIFF_DEBUG", "") == "true" {
-			fmt.Printf("Include Patterns:\n%s\n", string(includes))
-			fmt.Printf("Exclude Patterns:\n%s\n", string(excludes))
+			fmt.Println("Include Patterns:\n", includes)
+			fmt.Println("Exclude Patterns:\n", excludes)
 		}
 
 		include_files := []string{}
@@ -140,7 +140,7 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 		}
 
 		if env("MONOREPO_DIFF_DEBUG", "") == "true" {
-			fmt.Printf("Filtered Files:\n%s\n", string(include_files))
+			fmt.Println("Filtered Files:\n", include_files)
 		}
 
 		// Iterate over the filtered files for any matches
@@ -160,7 +160,7 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 	}
 
 	if env("MONOREPO_DIFF_DEBUG", "") == "true" {
-		fmt.Printf("Matched Steps:\n%s\n", string(steps))
+		fmt.Println("Matched Steps:\n", steps)
 	}
 
 	return dedupSteps(steps), nil

--- a/pipeline.go
+++ b/pipeline.go
@@ -127,13 +127,12 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 					}
 					if !match {
 						include_files = append(include_files, f)
-					} 
+					}
 				}
 			}
 		} else {
 			include_files = files
 		}
-
 
 		// Iterate over the filtered files for any matches
 		for _, i := range includes {

--- a/pipeline.go
+++ b/pipeline.go
@@ -119,14 +119,14 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 		include_files := []string{}
 		// try to match the excludes
 		if len(excludes) != 0 {
-			for _, e := range excludes {
-				if strings.HasPrefix(e, "!") {
-					e = e[1:]
-				}
-				for _, f := range files {
+			for _, f := range files {
+				for _, e := range excludes {
+					if strings.HasPrefix(e, "!") {
+						e = e[1:]
+					}
 					// If the file matches an exclude, move on to the next file.
 					if env("MONOREPO_DIFF_DEBUG", "") == "true" {
-						fmt.Println("Checking if exclude pattern matches:\n", includes)
+						fmt.Println("Checking if exclude pattern matches:")
 						fmt.Println("Pattern:\n", e)
 						fmt.Println("File:\n", f)
 					}
@@ -134,7 +134,15 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 					if err != nil {
 						return nil, err
 					}
-					if !match {
+					if match {
+						if env("MONOREPO_DIFF_DEBUG", "") == "true" {
+							fmt.Println("Excluding file.\n", f)
+						}
+						break
+					} else {
+						if env("MONOREPO_DIFF_DEBUG", "") == "true" {
+							fmt.Println("Pattern did not match.")
+						}
 						include_files = append(include_files, f)
 					}
 				}
@@ -149,8 +157,8 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 		}
 
 		// Iterate over the filtered files for any matches
-		for _, i := range includes {
-			for _, f := range include_files {
+		for _, f := range include_files {
+			for _, i := range includes {
 				match, err := matchPath(i, f)
 				if err != nil {
 					return nil, err

--- a/pipeline.go
+++ b/pipeline.go
@@ -125,6 +125,11 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 				}
 				for _, f := range files {
 					// If the file matches an exclude, move on to the next file.
+					if env("MONOREPO_DIFF_DEBUG", "") == "true" {
+						fmt.Println("Checking if exclude pattern matches:\n", includes)
+						fmt.Println("Pattern:\n", e)
+						fmt.Println("File:\n", f)
+					}
 					match, err := matchPath(e, f)
 					if err != nil {
 						return nil, err

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -222,6 +222,123 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 				{Trigger: "txt"},
 			},
 		},
+		"exclude extension wildcard in subdir": {
+			ChangedFiles: []string{
+				"docs/text.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"!docs/*.txt"},
+					Step:  Step{Trigger: "txt"},
+				},
+			},
+			Expected: []Step{
+			},
+		},
+		"exclude double directory and extension wildcard": {
+			ChangedFiles: []string{
+				"package/docs/other.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"!**/*.txt"},
+					Step:  Step{Trigger: "txt"},
+				},
+			},
+			Expected: []Step{
+			},
+		},
+		"excluded file changed": {
+			ChangedFiles: []string{
+				"watch-path-1/text2.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"watch-path-1/*", "!watch-path-1/text2.txt" },
+					Step:  Step{Trigger: "service-1"},
+				},
+			},
+			Expected: []Step{
+			},
+		},
+		"included and excluded files changed": {
+			ChangedFiles: []string{
+				"watch-path-1/text1.txt",
+				"watch-path-1/text2.txt",
+				"watch-path-1/text3.txt",
+				"watch-path-1/text4.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"watch-path-1/*", "!watch-path-1/text2.txt" },
+					Step:  Step{Trigger: "service-1"},
+				},
+				{
+					Paths: []string{"watch-path-1/*" },
+					Step:  Step{Trigger: "service-2"},
+				},
+			},
+			Expected: []Step{
+				{Trigger: "service-1"},
+				{Trigger: "service-2"},
+			},
+		},
+		"only excluded files changed": {
+			ChangedFiles: []string{
+				"watch-path-1/text2.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"watch-path-1/*", "!watch-path-1/text2.txt" },
+					Step:  Step{Trigger: "service-1"},
+				},
+				{
+					Paths: []string{"watch-path-1/*" },
+					Step:  Step{Trigger: "service-2"},
+				},
+			},
+			Expected: []Step{
+				{Trigger: "service-2"},
+			},
+		},
+		"included and excluded subdirectories changed": {
+			ChangedFiles: []string{
+				"watch-path-1/subdir1/text1.txt",
+				"watch-path-1/subdir2/text2.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"watch-path-1/**", "!watch-path-1/subdir2/**" },
+					Step:  Step{Trigger: "service-1"},
+				},
+				{
+					Paths: []string{"watch-path-1/**"},
+					Step:  Step{Trigger: "service-2"},
+				},
+			},
+			Expected: []Step{
+				{Trigger: "service-1"},
+				{Trigger: "service-2"},
+			},
+		},
+		"only excluded subdirectories changed": {
+			ChangedFiles: []string{
+				"watch-path-1/subdir2/text2.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"watch-path-1/**", "!watch-path-1/subdir2/**" },
+					Step:  Step{Trigger: "service-1"},
+				},
+				{
+					Paths: []string{"watch-path-1/**"},
+					Step:  Step{Trigger: "service-2"},
+				},
+			},
+			Expected: []Step{
+				{Trigger: "service-2"},
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -232,8 +232,7 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 					Step:  Step{Trigger: "txt"},
 				},
 			},
-			Expected: []Step{
-			},
+			Expected: []Step{},
 		},
 		"exclude double directory and extension wildcard": {
 			ChangedFiles: []string{
@@ -245,8 +244,7 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 					Step:  Step{Trigger: "txt"},
 				},
 			},
-			Expected: []Step{
-			},
+			Expected: []Step{},
 		},
 		"excluded file changed": {
 			ChangedFiles: []string{
@@ -254,12 +252,11 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			},
 			WatchConfigs: []WatchConfig{
 				{
-					Paths: []string{"watch-path-1/*", "!watch-path-1/text2.txt" },
+					Paths: []string{"watch-path-1/*", "!watch-path-1/text2.txt"},
 					Step:  Step{Trigger: "service-1"},
 				},
 			},
-			Expected: []Step{
-			},
+			Expected: []Step{},
 		},
 		"included and excluded files changed": {
 			ChangedFiles: []string{
@@ -270,11 +267,11 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			},
 			WatchConfigs: []WatchConfig{
 				{
-					Paths: []string{"watch-path-1/*", "!watch-path-1/text2.txt" },
+					Paths: []string{"watch-path-1/*", "!watch-path-1/text2.txt"},
 					Step:  Step{Trigger: "service-1"},
 				},
 				{
-					Paths: []string{"watch-path-1/*" },
+					Paths: []string{"watch-path-1/*"},
 					Step:  Step{Trigger: "service-2"},
 				},
 			},
@@ -289,11 +286,11 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			},
 			WatchConfigs: []WatchConfig{
 				{
-					Paths: []string{"watch-path-1/*", "!watch-path-1/text2.txt" },
+					Paths: []string{"watch-path-1/*", "!watch-path-1/text2.txt"},
 					Step:  Step{Trigger: "service-1"},
 				},
 				{
-					Paths: []string{"watch-path-1/*" },
+					Paths: []string{"watch-path-1/*"},
 					Step:  Step{Trigger: "service-2"},
 				},
 			},
@@ -308,7 +305,7 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			},
 			WatchConfigs: []WatchConfig{
 				{
-					Paths: []string{"watch-path-1/**", "!watch-path-1/subdir2/**" },
+					Paths: []string{"watch-path-1/**", "!watch-path-1/subdir2/**"},
 					Step:  Step{Trigger: "service-1"},
 				},
 				{
@@ -327,7 +324,7 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			},
 			WatchConfigs: []WatchConfig{
 				{
-					Paths: []string{"watch-path-1/**", "!watch-path-1/subdir2/**" },
+					Paths: []string{"watch-path-1/**", "!watch-path-1/subdir2/**"},
 					Step:  Step{Trigger: "service-1"},
 				},
 				{


### PR DESCRIPTION
This PR adds the ability to specify exclude patterns in the same list of file watcher patterns. 

Exclude patterns filter out modified files so their changes do not trigger those build steps.

Additionally I've added a bunch of debug prints when `MONOREPO_DIFF_DEBUG` environment variable is set. 