### PR TITLE
Add missing depends_on config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If the version number is not provided then the most recent version of the plugin
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.1:
+      - glydways/monorepo-diff#v2.6.1-alpha4:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -38,7 +38,7 @@ steps:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.1:
+      - glydways/monorepo-diff#v2.6.1-alpha4:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           env:
@@ -162,7 +162,7 @@ Add `log_level` property to set the log level. Supported log levels are `debug` 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.1:
+      - glydways/monorepo-diff#v2.6.1-alpha4:
           diff: "git diff --name-only HEAD~1"
           log_level: "debug" # defaults to "info"
           watch:
@@ -238,7 +238,7 @@ hooks:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.1:
+      - glydways/monorepo-diff#v2.6.1-alpha4:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: app/cms/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If the version number is not provided then the most recent version of the plugin
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.1-alpha4:
+      - glydways/monorepo-diff#v2.6.2:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -38,7 +38,7 @@ steps:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.1-alpha4:
+      - glydways/monorepo-diff#v2.6.2:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           env:
@@ -162,7 +162,7 @@ Add `log_level` property to set the log level. Supported log levels are `debug` 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.1-alpha4:
+      - glydways/monorepo-diff#v2.6.2:
           diff: "git diff --name-only HEAD~1"
           log_level: "debug" # defaults to "info"
           watch:
@@ -238,7 +238,7 @@ hooks:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.1-alpha4:
+      - glydways/monorepo-diff#v2.6.2:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: app/cms/

--- a/plugin.go
+++ b/plugin.go
@@ -88,6 +88,7 @@ type Step struct {
 	TimeoutInMinutes interface{}              `json:"timeout_in_minutes" yaml:"timeout_in_minutes,omitempty"`
 	Parallelism      interface{}              `json:"parallelism" yaml:"parallelism,omitempty"`
 	Retry            interface{}              `json:"retry" yaml:"retry,omitempty"`
+	DependsOn        interface{}              `json:"depends_on" yaml:"depends_on,omitempty"`
 }
 
 // Agent is Buildkite agent definition

--- a/plugin.yml
+++ b/plugin.yml
@@ -52,6 +52,8 @@ configuration:
               type: [object, integer]
             timeout_in_minutes:
               type: [object, integer]
+            depends_on:
+              type: [object, string]
             notify:
               type: [array]
               properties:


### PR DESCRIPTION
This is missing upstream but we need it for one of our PRs

https://buildkite.com/glydways/glyd-pull-request/builds/44022#019249c6-1186-4826-88b8-b42b888d2d59 has an example run where the root job failed so the `depends_on` children didn't run.