### PR TITLE
Add MONOREPO_DIFF_TRIGGER_ALL env var feature 2.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.5]
+
+### Added
+- `MONOREPO_DIFF_TRIGGER_ALL` env var: when `true`, fan out to every watched
+  step without running the diff. Intended for scheduled all-pipelines CI runs.
+
 ## [2.5.1]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -154,6 +154,28 @@ to avoid trying to interpolate the commit message, which can cause failures.
 
 The object values provided in this configuration will be appended to `env` property of all steps or commands.
 
+## `MONOREPO_DIFF_TRIGGER_ALL` (env var)
+
+When set to `"true"` in the build environment, the plugin skips the `diff` step
+and emits one trigger/command step per entry in `watch:`. Useful for scheduled
+fan-out builds (e.g. an hourly health check that exercises every downstream
+pipeline regardless of changed paths).
+
+```yaml
+# Schedule this build with env: MONOREPO_DIFF_TRIGGER_ALL=true
+steps:
+  - label: ":sparkles: trigger every pipeline"
+    plugins:
+      - glydways/monorepo-diff#v2.6.5:
+          watch:
+            - path: "foo-service/"
+              config:
+                trigger: "deploy-foo"
+            - path: "bar-service/"
+              config:
+                trigger: "deploy-bar"
+```
+
 ## `log_level` (optional)
 
 Add `log_level` property to set the log level. Supported log levels are `debug` and `info`. Defaults to `info`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If the version number is not provided then the most recent version of the plugin
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.4:
+      - glydways/monorepo-diff#v2.6.5:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -38,7 +38,7 @@ steps:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.4:
+      - glydways/monorepo-diff#v2.6.5:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           env:
@@ -184,7 +184,7 @@ Add `log_level` property to set the log level. Supported log levels are `debug` 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.4:
+      - glydways/monorepo-diff#v2.6.5:
           diff: "git diff --name-only HEAD~1"
           log_level: "debug" # defaults to "info"
           watch:
@@ -260,7 +260,7 @@ hooks:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - glydways/monorepo-diff#v2.6.4:
+      - glydways/monorepo-diff#v2.6.5:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: app/cms/

--- a/pipeline.go
+++ b/pipeline.go
@@ -44,22 +44,32 @@ func (n PluginNotify) MarshalYAML() (interface{}, error) {
 type PipelineGenerator func(steps []Step, plugin Plugin) (*os.File, error)
 
 func uploadPipeline(plugin Plugin, generatePipeline PipelineGenerator) (string, []string, error) {
-	diffOutput, err := diff(plugin.Diff)
-	if err != nil {
-		log.Fatal(err)
-		return "", []string{}, err
-	}
+	var steps []Step
 
-	if len(diffOutput) < 1 {
-		log.Info("No changes detected. Skipping pipeline upload.")
-		return "", []string{}, nil
-	}
+	if env("MONOREPO_DIFF_TRIGGER_ALL", "") == "true" {
+		log.Info("MONOREPO_DIFF_TRIGGER_ALL=true — emitting every watched step, skipping diff")
+		steps = make([]Step, 0, len(plugin.Watch))
+		for _, w := range plugin.Watch {
+			steps = append(steps, w.Step)
+		}
+	} else {
+		diffOutput, err := diff(plugin.Diff)
+		if err != nil {
+			log.Fatal(err)
+			return "", []string{}, err
+		}
 
-	log.Debug("Output from diff: \n" + strings.Join(diffOutput, "\n"))
+		if len(diffOutput) < 1 {
+			log.Info("No changes detected. Skipping pipeline upload.")
+			return "", []string{}, nil
+		}
 
-	steps, err := stepsToTrigger(diffOutput, plugin.Watch)
-	if err != nil {
-		return "", []string{}, err
+		log.Debug("Output from diff: \n" + strings.Join(diffOutput, "\n"))
+
+		steps, err = stepsToTrigger(diffOutput, plugin.Watch)
+		if err != nil {
+			return "", []string{}, err
+		}
 	}
 
 	pipeline, err := generatePipeline(steps, plugin)

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -43,6 +43,35 @@ func TestUploadPipelineCancelsIfThereIsNoDiffOutput(t *testing.T) {
 	assert.Equal(t, err, nil)
 }
 
+func TestUploadPipelineTriggerAllSkipsDiffAndEmitsAllWatches(t *testing.T) {
+	t.Setenv("MONOREPO_DIFF_TRIGGER_ALL", "true")
+
+	var captured []Step
+	gen := func(steps []Step, plugin Plugin) (*os.File, error) {
+		captured = steps
+		f, _ := os.Create("pipeline.txt")
+		defer f.Close()
+		return f, nil
+	}
+
+	plugin := Plugin{
+		Diff: "false", // would fail if executed; proves we skip diff
+		Watch: []WatchConfig{
+			{Paths: []string{"a/"}, Step: Step{Trigger: "svc-a"}},
+			{Paths: []string{"b/"}, Step: Step{Trigger: "svc-b"}},
+		},
+	}
+
+	_, _, err := uploadPipeline(plugin, gen)
+
+	// Only error expected is from missing buildkite-agent binary, not from diff.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "buildkite-agent")
+	require.Len(t, captured, 2)
+	assert.Equal(t, "svc-a", captured[0].Trigger)
+	assert.Equal(t, "svc-b", captured[1].Trigger)
+}
+
 func TestDiff(t *testing.T) {
 	want := []string{
 		"services/foo/serverless.yml",

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -52,6 +52,40 @@ steps:
 EOM
 }
 
+@test "MONOREPO_DIFF_TRIGGER_ALL emits every watched step and skips diff" {
+  export MONOREPO_DIFF_TRIGGER_ALL="true"
+
+  # diff is intentionally a failing command — if it ran, the build would fail.
+  export BUILDKITE_PLUGINS='[{
+    "github.com/glydways/monorepo-diff-buildkite-plugin": {
+      "diff": "exit 1",
+      "log_level": "debug",
+      "watch": [
+        {
+          "path": "foo-service/",
+          "config": { "trigger": "foo-pipeline" }
+        },
+        {
+          "path": "bar-service/",
+          "config": { "trigger": "bar-pipeline" }
+        }
+      ]
+    }
+  }]'
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "MONOREPO_DIFF_TRIGGER_ALL=true"
+  assert_output --partial << EOM
+steps:
+- trigger: foo-pipeline
+EOM
+  assert_output --partial << EOM
+- trigger: bar-pipeline
+EOM
+}
+
 @test "Pipeline is generated with notifications" {
   export BUILDKITE_BRANCH="go-rewrite"
   export BUILDKITE_MESSAGE="some message"


### PR DESCRIPTION
This allows us to essentially override the file based trigger and run everything with an
environment variable.

We test this with additional integration tests and unit tests.